### PR TITLE
utilize paper player profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
             <version>1.18.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,9 +119,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
-                <configuration>
-                    <release>17</release>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -120,8 +120,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>16</source>
+                    <target>16</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/de/fanta/fancyfirework/utils/CustomFireworkHeads.java
+++ b/src/main/java/de/fanta/fancyfirework/utils/CustomFireworkHeads.java
@@ -1,10 +1,12 @@
 package de.fanta.fancyfirework.utils;
 
-import com.mojang.authlib.GameProfile;
-import com.mojang.authlib.properties.Property;
+import com.destroystokyo.paper.profile.PlayerProfile;
+import com.destroystokyo.paper.profile.ProfileProperty;
 import de.fanta.fancyfirework.FancyFirework;
 import de.iani.cubesideutils.bukkit.items.CustomHeads;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 
@@ -17,8 +19,10 @@ public class CustomFireworkHeads {
         if (!FancyFirework.getPlugin().hasPlayerProfileAPI()) {
             ItemStack head = new ItemStack(Material.PLAYER_HEAD, 1);
             SkullMeta meta = (SkullMeta) head.getItemMeta();
-            GameProfile profile = new GameProfile(uuid, "");
-            profile.getProperties().put("textures", new Property("textures", value));
+            Player player = Bukkit.getPlayer(uuid);
+            PlayerProfile profile = player.getPlayerProfile();
+            ProfileProperty property = new ProfileProperty("textures", value);
+            profile.setProperty(property);
             Field profileField;
             try {
                 profileField = meta.getClass().getDeclaredField("profile");


### PR DESCRIPTION
Not sure what the proper way to do this is. I want to utilize fancy fireworks as a dependency to one of the plugins I'm developing. I tried adding the dependency using jitpack but it had problems compiling. This would utilize the paper api instead of using the internal mojang libraries for profiles.